### PR TITLE
mongo package replaced with maintanied version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ lint:
 
 deps:
 	@echo "$(OK_COLOR)==> Installing dependencies $(NO_COLOR)"
-	@go get -u gopkg.in/mgo.v2
+	@go get -u github.com/globalsign/mgo
 	@go get -u github.com/go-sql-driver/mysql
 	@go get -u github.com/lib/pq
 	@go get -u github.com/streadway/amqp

--- a/checks/mongo/check.go
+++ b/checks/mongo/check.go
@@ -1,6 +1,6 @@
 package mongo
 
-import "gopkg.in/mgo.v2"
+import "github.com/globalsign/mgo"
 
 // Config is the MongoDB checker configuration settings container.
 type Config struct {


### PR DESCRIPTION
The mongo driver used in the project is not maintained ~2 years and won't be maintained anymore. Over the time fork of the package has been maintained and still active.

PR replaces it with maintained package.