### PR TITLE
Fix rare corner cases that can panic or block on channels

### DIFF
--- a/checks/rabbitmq/check.go
+++ b/checks/rabbitmq/check.go
@@ -94,12 +94,17 @@ func New(config Config) func() error {
 			return err
 		}
 
-		done := make(chan struct{}, 1)
-		defer close(done)
+		done := make(chan struct{})
 
 		go func() {
+			// block until: a message is received, or message channel is closed (consume timeout)
+			<-message
+
+			// release the channel resources, and unblock the receive on done below
+			close(done)
+
+			// now drain any incidental remaining messages
 			for range messages {
-				done <- struct{}{}
 			}
 		}()
 

--- a/checks/rabbitmq/check.go
+++ b/checks/rabbitmq/check.go
@@ -98,7 +98,7 @@ func New(config Config) func() error {
 
 		go func() {
 			// block until: a message is received, or message channel is closed (consume timeout)
-			<-message
+			<-messages
 
 			// release the channel resources, and unblock the receive on done below
 			close(done)


### PR DESCRIPTION
If there is a `"consume timeout"` the closing of the `done` channel can [_happen before_](https://golang.org/ref/mem#tmp_2) an attempt to send on the `done` channel (i.e. a `message` is received _after_ the `close(done)` but _before_ the `ch.Close()` ). Despite the `done` channel having a buffer of one, this will panic because it is a closed channel, and crash the whole process. Since no other goroutine `defer`s execute, logs will not be flushed either.

Additionally, if the `message` channel unexpectedly receives a second message, then the goroutine will block attempting to send another `struct{}{}` on the `done` channel, which will block that goroutine—leaking a goroutine and a channel.