### PR TITLE
[BAZ-8554]-Implementing command line healthchecks

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,3 +17,5 @@ require (
 	golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4 // indirect
 	google.golang.org/appengine v1.4.0 // indirect
 )
+
+go 1.13


### PR DESCRIPTION
- What was done?
 -Was added new healthcheck modes as standalone e customizable
Why it is done?
 -Event Cloud lib from go, does not allow the exposition of another resources, including /health, then it was necessary to Kubernetes verify the app external dependencies health