### PR TITLE
EES-4396 No more package-level vars, use instance instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,42 +25,44 @@ Additionally, library exports `Measure` function that returns summary status for
 package main
 
 import (
-  "context"
-  "net/http"
-  "time"
+	"context"
+	"net/http"
+	"time"
 
-  "github.com/hellofresh/health-go/v4"
-  healthMysql "github.com/hellofresh/health-go/v4/checks/mysql"
+	"github.com/hellofresh/health-go/v4"
+	healthMysql "github.com/hellofresh/health-go/v4/checks/mysql"
 )
 
 func main() {
-  health.Register(health.Config{
-    Name: "rabbitmq",
-    Timeout: time.Second*5,
-    SkipOnErr: true,
-    Check: func(ctx context.Context) error {
-      // rabbitmq health check implementation goes here
-    },
-  })
+	// add some checks on instance creation
+	h, _ := health.New(health.WithChecks(health.Config{
+		Name:      "rabbitmq",
+		Timeout:   time.Second * 5,
+		SkipOnErr: true,
+		Check: func(ctx context.Context) error {
+			// rabbitmq health check implementation goes here
+			return nil
+		}}, health.Config{
+		Name: "mongodb",
+		Check: func(ctx context.Context) error {
+			// mongo_db health check implementation goes here
+			return nil
+		},
+	},
+	))
 
-  health.Register(health.Config{
-    Name: "mongodb",
-    Check: func(ctx context.Context) error {
-      // mongo_db health check implementation goes here
-    },
-  })
-  
-  health.Register(health.Config{
-    Name:      "mysql",
-    Timeout:   time.Second * 2,
-    SkipOnErr: false,
-    Check: healthMysql.New(healthMysql.Config{
-      DSN: "test:test@tcp(0.0.0.0:31726)/test?charset=utf8",
-    },
-  })
+	// and then add some more if needed
+	h.Register(health.Config{
+		Name:      "mysql",
+		Timeout:   time.Second * 2,
+		SkipOnErr: false,
+		Check: healthMysql.New(healthMysql.Config{
+			DSN: "test:test@tcp(0.0.0.0:31726)/test?charset=utf8",
+		}),
+	})
 
-  http.Handle("/status", health.Handler())
-  http.ListenAndServe(":3000", nil)
+	http.Handle("/status", h.Handler())
+	http.ListenAndServe(":3000", nil)
 }
 ```
 
@@ -69,44 +71,46 @@ func main() {
 package main
 
 import (
-  "context"    
-  "net/http"
-  "time"
+	"context"
+	"net/http"
+	"time"
 
-  "github.com/go-chi/chi"
-  "github.com/hellofresh/health-go/v4"
-  healthMysql "github.com/hellofresh/health-go/v4/checks/mysql"
+	"github.com/go-chi/chi"
+	"github.com/hellofresh/health-go/v4"
+	healthMysql "github.com/hellofresh/health-go/v4/checks/mysql"
 )
 
 func main() {
-  health.Register(health.Config{
-    Name: "rabbitmq",
-    Timeout: time.Second*5,
-    SkipOnErr: true,
-    Check: func(ctx context.Context) error {
-      // rabbitmq health check implementation goes here
-    }),
-  })
+	// add some checks on instance creation
+	h, _ := health.New(health.WithChecks(health.Config{
+		Name:      "rabbitmq",
+		Timeout:   time.Second * 5,
+		SkipOnErr: true,
+		Check: func(ctx context.Context) error {
+			// rabbitmq health check implementation goes here
+			return nil
+		}}, health.Config{
+		Name: "mongodb",
+		Check: func(ctx context.Context) error {
+			// mongo_db health check implementation goes here
+			return nil
+		},
+	},
+	))
 
-  health.Register(health.Config{
-    Name: "mongodb",
-    Check: func(ctx context.Context) error {
-      // mongo_db health check implementation goes here
-    },
-  })
-  
-  health.Register(health.Config{
-    Name:      "mysql",
-    Timeout:   time.Second * 2,
-    SkipOnErr: false,
-    Check: healthMysql.New(healthMysql.Config{
-      DSN:               "test:test@tcp(0.0.0.0:31726)/test?charset=utf8",
-    },
-  })
+	// and then add some more if needed
+	h.Register(health.Config{
+		Name:      "mysql",
+		Timeout:   time.Second * 2,
+		SkipOnErr: false,
+		Check: healthMysql.New(healthMysql.Config{
+			DSN: "test:test@tcp(0.0.0.0:31726)/test?charset=utf8",
+		}),
+	})
 
-  r := chi.NewRouter()
-  r.Get("/status", health.HandlerFunc)
-  http.ListenAndServe(":3000", nil)
+	r := chi.NewRouter()
+	r.Get("/status", h.HandlerFunc)
+	http.ListenAndServe(":3000", nil)
 }
 ```
 

--- a/options.go
+++ b/options.go
@@ -1,0 +1,19 @@
+package health
+
+import "fmt"
+
+// Option is the health-container options type
+type Option func(*Health) error
+
+// WithChecks adds checks to newly instantiated health-container
+func WithChecks(checks ...Config) Option {
+	return func(h *Health) error {
+		for _, c := range checks {
+			if err := h.Register(c); err != nil {
+				return fmt.Errorf("could not register check %q: %w", c.Name, err)
+			}
+		}
+
+		return nil
+	}
+}

--- a/options_test.go
+++ b/options_test.go
@@ -1,0 +1,29 @@
+package health
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWithChecks(t *testing.T) {
+	h1, err := New()
+	require.NoError(t, err)
+	assert.Len(t, h1.checks, 0)
+
+	h2, err := New(WithChecks(Config{
+		Name: "foo",
+	}, Config{
+		Name: "bar",
+	}))
+	require.NoError(t, err)
+	assert.Len(t, h2.checks, 2)
+
+	_, err = New(WithChecks(Config{
+		Name: "foo",
+	}, Config{
+		Name: "foo",
+	}))
+	require.Error(t, err)
+}


### PR DESCRIPTION
Getting rid of one of the go packages antipatterns - replaced package level private vars with an instance. This also allows to create different health-checks within single app if someone will really need it.