### PR TITLE
EES-4396 Run checks concurrently

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,11 @@ services:
       POSTGRES_USER: test
       POSTGRES_PASSWORD: test
       POSTGRES_DB: test
+    healthcheck:
+      test: [ "CMD", "pg_isready" ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
   pg-pgx4:
     image: postgres:9.6-alpine


### PR DESCRIPTION
Current implementation runs checks consequently, this PR changes behaviour to run all the tests concurrently, so that it  should take less time.