### PR TITLE
[rabbitmq] add context to healthcheck

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 vendor/
 coverage.txt
+.idea/

--- a/checks/rabbitmq/check.go
+++ b/checks/rabbitmq/check.go
@@ -127,7 +127,7 @@ func New(config Config) func(ctx context.Context) error {
 				return
 			case <-ctx.Done():
 				checkErr = fmt.Errorf("RabbitMQ health check failed due "+
-					"to health check listener disconnect: %s", ctx.Err())
+					"to health check listener disconnect: %w", ctx.Err())
 				return
 			case <-done:
 				return


### PR DESCRIPTION
Hi! I have found that there is no context usage in healthcheck for rabbitmq.

Also I've found that, if I firewall some node on 'DROP', my healthcheck will never finish.

If I successfully dial, but something happens with rabbitmq, healthcheck is not going to finish. I think that it is some amqp library issues. But now I add only context and dial timeout.