### PR TITLE
feature: allow to add a component description alongside system infos

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,10 @@ import (
 
 func main() {
 	// add some checks on instance creation
-	h, _ := health.New(health.WithChecks(health.Config{
+	h, _ := health.New(health.WithComponent(health.Component{
+      Name:    "myservice",
+      Version: "v1.0",
+    }), health.WithChecks(health.Config{
 		Name:      "rabbitmq",
 		Timeout:   time.Second * 5,
 		SkipOnErr: true,
@@ -85,7 +88,10 @@ import (
 
 func main() {
 	// add some checks on instance creation
-	h, _ := health.New(health.WithChecks(health.Config{
+	h, _ := health.New(health.WithComponent(health.Component{
+      Name:    "myservice",
+      Version: "v1.0",
+    }), health.WithChecks(health.Config{
 		Name:      "rabbitmq",
 		Timeout:   time.Second * 5,
 		SkipOnErr: true,
@@ -142,6 +148,10 @@ HTTP/1.1 200 OK
     "total_alloc_bytes": 21321,
     "heap_objects_count": 21323,
     "alloc_bytes": 234523
+  },
+  "component": {
+    "name": "myservice",
+    "version": "v1.0"
   }
 }
 ```
@@ -160,6 +170,10 @@ HTTP/1.1 200 OK
     "total_alloc_bytes": 21321,
     "heap_objects_count": 21323,
     "alloc_bytes": 234523
+  },
+  "component": {
+    "name": "myservice",
+    "version": "v1.0"
   }
 }
 ```
@@ -178,6 +192,10 @@ HTTP/1.1 503 Service Unavailable
     "total_alloc_bytes": 21321,
     "heap_objects_count": 21323,
     "alloc_bytes": 234523
+  },
+  "component": {
+    "name": "myservice",
+    "version": "v1.0"
   }
 }
 ```

--- a/health.go
+++ b/health.go
@@ -52,6 +52,8 @@ type (
 		Failures map[string]string `json:"failures,omitempty"`
 		// System holds information of the go process.
 		System `json:"system"`
+		// Component holds information on the component for which checks are made
+		Component `json:"component"`
 	}
 
 	// System runtime variables about the go process.
@@ -68,6 +70,14 @@ type (
 		AllocBytes int `json:"alloc_bytes"`
 	}
 
+	// Component descriptive values about the component for which checks are made
+	Component struct {
+		// Name is the name of the component.
+		Name string `json:"name"`
+		// Version is the component version.
+		Version string `json:"version"`
+	}
+
 	// Health is the health-checks container
 	Health struct {
 		mu     sync.Mutex
@@ -75,6 +85,8 @@ type (
 
 		tp                  trace.TracerProvider
 		instrumentationName string
+
+		component Component
 	}
 
 	checkResponse struct {
@@ -228,15 +240,16 @@ func (h *Health) Measure(ctx context.Context) Check {
 
 	span.SetAttributes(attribute.String("status", string(status)))
 
-	return newCheck(status, failures)
+	return newCheck(h.component, status, failures)
 }
 
-func newCheck(s Status, failures map[string]string) Check {
+func newCheck(c Component, s Status, failures map[string]string) Check {
 	return Check{
 		Status:    s,
 		Timestamp: time.Now(),
 		Failures:  failures,
 		System:    newSystemMetrics(),
+		Component: c,
 	}
 }
 

--- a/options.go
+++ b/options.go
@@ -32,3 +32,12 @@ func WithTracerProvider(tp trace.TracerProvider, instrumentationName string) Opt
 		return nil
 	}
 }
+
+// WithComponent sets the component description of the component to which this check refer
+func WithComponent(component Component) Option {
+	return func(h *Health) error {
+		h.component = component
+
+		return nil
+	}
+}

--- a/options_test.go
+++ b/options_test.go
@@ -54,3 +54,19 @@ func TestWithTracerProvider(t *testing.T) {
 	assert.Same(t, tp, h2.tp)
 	assert.Equal(t, instrumentationName, h2.instrumentationName)
 }
+
+func TestWithComponent(t *testing.T) {
+	h1, err := New()
+	require.NoError(t, err)
+	assert.Empty(t, h1.component.Name)
+	assert.Empty(t, h1.component.Version)
+
+	c := new(Component)
+	c.Name = "test"
+	c.Version = "1.0"
+
+	h2, err := New(WithComponent(*c))
+	require.NoError(t, err)
+	assert.Equal(t, "test", h2.component.Name)
+	assert.Equal(t, "1.0", h2.component.Version)
+}

--- a/options_test.go
+++ b/options_test.go
@@ -61,11 +61,12 @@ func TestWithComponent(t *testing.T) {
 	assert.Empty(t, h1.component.Name)
 	assert.Empty(t, h1.component.Version)
 
-	c := new(Component)
-	c.Name = "test"
-	c.Version = "1.0"
+	c := Component{
+		Name:    "test",
+		Version: "1.0",
+	}
 
-	h2, err := New(WithComponent(*c))
+	h2, err := New(WithComponent(c))
 	require.NoError(t, err)
 	assert.Equal(t, "test", h2.component.Name)
 	assert.Equal(t, "1.0", h2.component.Version)


### PR DESCRIPTION
### Description

This PR is about allowing someone to provide a brief description of the component (name and version) on which health check is performed so that it is easy to relate the status to the source component of the checks. 

If the component is not provided then the status will print empty values for both name and version.