### PR TITLE
Prevent Check to send result to closed channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,16 +32,16 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/hellofresh/health-go/v4"
-	healthMysql "github.com/hellofresh/health-go/v4/checks/mysql"
+	"github.com/hellofresh/health-go/v5"
+	healthMysql "github.com/hellofresh/health-go/v5/checks/mysql"
 )
 
 func main() {
 	// add some checks on instance creation
 	h, _ := health.New(health.WithComponent(health.Component{
-      Name:    "myservice",
-      Version: "v1.0",
-    }), health.WithChecks(health.Config{
+		Name:    "myservice",
+		Version: "v1.0",
+	}), health.WithChecks(health.Config{
 		Name:      "rabbitmq",
 		Timeout:   time.Second * 5,
 		SkipOnErr: true,
@@ -82,16 +82,16 @@ import (
 	"time"
 
 	"github.com/go-chi/chi"
-	"github.com/hellofresh/health-go/v4"
-	healthMysql "github.com/hellofresh/health-go/v4/checks/mysql"
+	"github.com/hellofresh/health-go/v5"
+	healthMysql "github.com/hellofresh/health-go/v5/checks/mysql"
 )
 
 func main() {
 	// add some checks on instance creation
 	h, _ := health.New(health.WithComponent(health.Component{
-      Name:    "myservice",
-      Version: "v1.0",
-    }), health.WithChecks(health.Config{
+		Name:    "myservice",
+		Version: "v1.0",
+	}), health.WithChecks(health.Config{
 		Name:      "rabbitmq",
 		Timeout:   time.Second * 5,
 		SkipOnErr: true,

--- a/_examples/server.go
+++ b/_examples/server.go
@@ -6,10 +6,10 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/hellofresh/health-go/v4"
-	healthHttp "github.com/hellofresh/health-go/v4/checks/http"
-	healthMySql "github.com/hellofresh/health-go/v4/checks/mysql"
-	healthPg "github.com/hellofresh/health-go/v4/checks/postgres"
+	"github.com/hellofresh/health-go/v5"
+	healthHttp "github.com/hellofresh/health-go/v5/checks/http"
+	healthMySql "github.com/hellofresh/health-go/v5/checks/mysql"
+	healthPg "github.com/hellofresh/health-go/v5/checks/postgres"
 )
 
 func main() {

--- a/checks/rabbitmq/aliveness_check_test.go
+++ b/checks/rabbitmq/aliveness_check_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/hellofresh/health-go/v4/checks/http"
+	"github.com/hellofresh/health-go/v5/checks/http"
 )
 
 const httpURLEnv = "HEALTH_GO_MQ_URL"

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,8 +30,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/hellofresh/health-go/v4"
-	healthMysql "github.com/hellofresh/health-go/v4/checks/mysql"
+	"github.com/hellofresh/health-go/v5"
+	healthMysql "github.com/hellofresh/health-go/v5/checks/mysql"
 )
 
 func main() {
@@ -77,8 +77,8 @@ import (
 	"time"
 
 	"github.com/go-chi/chi"
-	"github.com/hellofresh/health-go/v4"
-	healthMysql "github.com/hellofresh/health-go/v4/checks/mysql"
+	"github.com/hellofresh/health-go/v5"
+	healthMysql "github.com/hellofresh/health-go/v5/checks/mysql"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/hellofresh/health-go/v4
+module github.com/hellofresh/health-go/v5
 
 go 1.18
 

--- a/health.go
+++ b/health.go
@@ -194,18 +194,10 @@ func (h *Health) Measure(ctx context.Context) Check {
 			}()
 
 			resCh := make(chan error)
-			defer close(resCh)
 
 			go func() {
-				res := c.Check(ctx)
-
-				select {
-				case <-resCh:
-					// channel is already closed
-					return
-				default:
-					resCh <- res
-				}
+				resCh <- c.Check(ctx)
+				defer close(resCh)
 			}()
 
 			select {


### PR DESCRIPTION
This PR prevents a race condition between timeout and the Check execution result by delegating the closing command to the goroutine where the Check work done.

Since the work happened before checking the channel state the performance should not be impacted.

Closes #84  