### PR TITLE
disable empty-block revive rule in rabbitmq check

### DIFF
--- a/checks/rabbitmq/check.go
+++ b/checks/rabbitmq/check.go
@@ -106,9 +106,10 @@ func New(config Config) func(ctx context.Context) error {
 			// release the channel resources, and unblock the receive on done below
 			close(done)
 
-			// now drain any incidental remaining messages
+			//revive:disable:empty-block Draining any incidental remaining messages
 			for range messages {
 			}
+			//revive:enable:empty-block
 		}()
 
 		p := amqp.Publishing{Body: []byte(time.Now().Format(time.RFC3339Nano))}


### PR DESCRIPTION
This PR disables the empty-block rule from revive linter in rabbitmq check, as the for-loop is only for draining messages and is intentionally empty.