### PR TITLE
Enhance health status codes and add finer grain control over status

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,14 +46,14 @@ func main() {
 		Name:      "rabbitmq",
 		Timeout:   time.Second * 5,
 		SkipOnErr: true,
-		Check: func(ctx context.Context) error {
+		Check: func(ctx context.Context) (healthResponse health.CheckResponse) {
 			// rabbitmq health check implementation goes here
-			return nil
+			return
 		}}, health.Config{
 		Name: "mongodb",
-		Check: func(ctx context.Context) error {
+		Check: func(ctx context.Context) (healthResponse health.CheckResponse) {
 			// mongo_db health check implementation goes here
-			return nil
+			return
 		},
 	},
 	))
@@ -96,14 +96,14 @@ func main() {
 		Name:      "rabbitmq",
 		Timeout:   time.Second * 5,
 		SkipOnErr: true,
-		Check: func(ctx context.Context) error {
+		Check: func(ctx context.Context) (healthResponse health.CheckResponse) {
 			// rabbitmq health check implementation goes here
-			return nil
+			return
 		}}, health.Config{
 		Name: "mongodb",
-		Check: func(ctx context.Context) error {
+		Check: func(ctx context.Context) (healthResponse health.CheckResponse) {
 			// mongo_db health check implementation goes here
-			return nil
+			return
 		},
 	},
 	))
@@ -141,7 +141,7 @@ curl localhost:3000/status
 HTTP/1.1 200 OK
 ```json
 {
-  "status": "OK",
+  "status": "passing",
   "timestamp": "2017-01-01T00:00:00.413567856+033:00",
   "system": {
     "version": "go1.8",
@@ -160,7 +160,7 @@ HTTP/1.1 200 OK
 HTTP/1.1 200 OK
 ```json
 {
-  "status": "Partially Available",
+  "status": "warning",
   "timestamp": "2017-01-01T00:00:00.413567856+033:00",
   "failures": {
     "rabbitmq": "Failed during rabbitmq health check"
@@ -182,7 +182,7 @@ HTTP/1.1 200 OK
 HTTP/1.1 503 Service Unavailable
 ```json
 {
-  "status": "Unavailable",
+  "status": "critical",
   "timestamp": "2017-01-01T00:00:00.413567856+033:00",
   "failures": {
     "mongodb": "Failed during mongodb health check"

--- a/_examples/server.go
+++ b/_examples/server.go
@@ -19,13 +19,15 @@ func main() {
 		Name:      "some-custom-check-fail",
 		Timeout:   time.Second * 5,
 		SkipOnErr: true,
-		Check:     func(context.Context) error { return errors.New("failed during custom health check") },
+		Check: func(context.Context) health.CheckResponse {
+			return health.CheckResponse{Error: errors.New("failed during custom health check")}
+		},
 	})
 
 	// custom health check example (success)
 	h.Register(health.Config{
 		Name:  "some-custom-check-success",
-		Check: func(context.Context) error { return nil },
+		Check: func(context.Context) health.CheckResponse { return health.CheckResponse{} },
 	})
 
 	// http health check example

--- a/checks/cassandra/check_test.go
+++ b/checks/cassandra/check_test.go
@@ -23,14 +23,14 @@ func TestNew(t *testing.T) {
 	})
 
 	err := check(context.Background())
-	require.NoError(t, err)
+	require.NoError(t, err.Error)
 }
 
 func TestNewWithError(t *testing.T) {
 	check := New(Config{})
 
 	err := check(context.Background())
-	require.Error(t, err)
+	require.Error(t, err.Error)
 }
 
 func initDB(t *testing.T) {

--- a/checks/grpc/check_test.go
+++ b/checks/grpc/check_test.go
@@ -61,12 +61,12 @@ func TestNew(t *testing.T) {
 				},
 			})
 
-			err = check(context.Background())
+			checkResponse := check(context.Background())
 
 			if requireError {
-				require.Error(t, err)
+				require.Error(t, checkResponse.Error)
 			} else {
-				require.NoError(t, err)
+				require.NoError(t, checkResponse.Error)
 			}
 		})
 	}

--- a/checks/http/check.go
+++ b/checks/http/check.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/hellofresh/health-go/v5"
 	"net/http"
 	"time"
 )
@@ -23,15 +24,16 @@ type Config struct {
 // - connection establishing
 // - getting response status from defined URL
 // - verifying that status code is less than 500
-func New(config Config) func(ctx context.Context) error {
+func New(config Config) func(ctx context.Context) health.CheckResponse {
 	if config.RequestTimeout == 0 {
 		config.RequestTimeout = defaultRequestTimeout
 	}
 
-	return func(ctx context.Context) error {
+	return func(ctx context.Context) (checkResponse health.CheckResponse) {
 		req, err := http.NewRequest(http.MethodGet, config.URL, nil)
 		if err != nil {
-			return fmt.Errorf("creating the request for the health check failed: %w", err)
+			checkResponse.Error = fmt.Errorf("creating the request for the health check failed: %w", err)
+			return
 		}
 
 		ctx, cancel := context.WithTimeout(ctx, config.RequestTimeout)
@@ -43,14 +45,16 @@ func New(config Config) func(ctx context.Context) error {
 
 		res, err := http.DefaultClient.Do(req)
 		if err != nil {
-			return fmt.Errorf("making the request for the health check failed: %w", err)
+			checkResponse.Error = fmt.Errorf("making the request for the health check failed: %w", err)
+			return
 		}
 		defer res.Body.Close()
 
 		if res.StatusCode >= http.StatusInternalServerError {
-			return errors.New("remote service is not available at the moment")
+			checkResponse.Error = errors.New("remote service is not available at the moment")
+			return
 		}
 
-		return nil
+		return
 	}
 }

--- a/checks/http/check_test.go
+++ b/checks/http/check_test.go
@@ -24,7 +24,7 @@ func TestNew(t *testing.T) {
 		})
 
 		err := check(context.Background())
-		require.NoError(t, err)
+		require.NoError(t, err.Error)
 		assert.True(t, svc200.Called())
 	})
 
@@ -36,7 +36,7 @@ func TestNew(t *testing.T) {
 		})
 
 		err := check(context.Background())
-		require.Error(t, err)
+		require.Error(t, err.Error)
 		assert.True(t, svc500.Called())
 	})
 }

--- a/checks/influxdb/check.go
+++ b/checks/influxdb/check.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/hellofresh/health-go/v5"
 
 	influxdb2 "github.com/influxdata/influxdb-client-go/v2"
 	"github.com/influxdata/influxdb-client-go/v2/domain"
@@ -17,8 +18,8 @@ type Config struct {
 
 // New returns a check function. It uses InfluxDB health api
 // to get status of the instance.
-func New(config Config) func(ctx context.Context) error {
-	return func(ctx context.Context) error {
+func New(config Config) func(ctx context.Context) health.CheckResponse {
+	return func(ctx context.Context) (checkResponse health.CheckResponse) {
 		// since only health api will be used, we don't need to pass
 		// any Authorization data (token in this case)
 		client := influxdb2.NewClient(config.URL, "")
@@ -27,14 +28,16 @@ func New(config Config) func(ctx context.Context) error {
 		h, err := client.Health(ctx)
 
 		if err != nil {
-			return fmt.Errorf("InfluxDB health check failed: %w", err)
+			checkResponse.Error = fmt.Errorf("InfluxDB health check failed: %w", err)
+			return
 		}
 
 		// any status different from "pass" is considered as failed
 		if h.Status != domain.HealthCheckStatusPass {
-			return errors.New("InfluxDB health check failed, didn't get PASS status")
+			checkResponse.Error = errors.New("InfluxDB health check failed, didn't get PASS status")
+			return
 		}
 
-		return nil
+		return
 	}
 }

--- a/checks/influxdb/check_test.go
+++ b/checks/influxdb/check_test.go
@@ -16,7 +16,7 @@ func TestNew(t *testing.T) {
 	})
 
 	err := check(context.Background())
-	require.NoError(t, err)
+	require.NoError(t, err.Error)
 }
 
 func TestNewWithError(t *testing.T) {
@@ -25,7 +25,7 @@ func TestNewWithError(t *testing.T) {
 	})
 
 	err := check(context.Background())
-	require.Error(t, err)
+	require.Error(t, err.Error)
 }
 
 func getURL(t *testing.T) string {

--- a/checks/memcached/check.go
+++ b/checks/memcached/check.go
@@ -3,6 +3,7 @@ package memcached
 import (
 	"context"
 	"fmt"
+	"github.com/hellofresh/health-go/v5"
 	"strings"
 
 	"github.com/bradfitz/gomemcache/memcache"
@@ -17,22 +18,23 @@ type Config struct {
 // New creates new Memcached health check that verifies the following:
 // - connection establishing
 // - doing the PING command and verifying the response
-func New(config Config) func(ctx context.Context) error {
+func New(config Config) func(ctx context.Context) health.CheckResponse {
 	// support all DSN formats (for backward compatibility) - with and w/out schema and path part:
 	// - memcached://localhost:11211/
 	// - localhost:11211
 	memcachedDSN := strings.TrimPrefix(config.DSN, "memcached://")
 	memcachedDSN = strings.TrimSuffix(memcachedDSN, "/")
 
-	return func(_ context.Context) error {
+	return func(_ context.Context) (checkResponse health.CheckResponse) {
 		mdb := memcache.New(memcachedDSN)
 
 		err := mdb.Ping()
 
 		if err != nil {
-			return fmt.Errorf("memcached ping failed: %w", err)
+			checkResponse.Error = fmt.Errorf("memcached ping failed: %w", err)
+			return
 		}
 
-		return nil
+		return
 	}
 }

--- a/checks/memcached/check_test.go
+++ b/checks/memcached/check_test.go
@@ -16,7 +16,7 @@ func TestNew(t *testing.T) {
 	})
 
 	err := check(context.Background())
-	require.NoError(t, err)
+	require.NoError(t, err.Error)
 }
 
 func TestNewError(t *testing.T) {
@@ -25,7 +25,7 @@ func TestNewError(t *testing.T) {
 	})
 
 	err := check(context.Background())
-	require.Error(t, err)
+	require.Error(t, err.Error)
 }
 
 func getDSN(t *testing.T) string {

--- a/checks/mongo/check_test.go
+++ b/checks/mongo/check_test.go
@@ -17,7 +17,7 @@ func TestNew(t *testing.T) {
 	})
 
 	err := check(context.Background())
-	require.NoError(t, err)
+	require.NoError(t, err.Error)
 }
 
 func getDSN(t *testing.T) string {

--- a/checks/mysql/check.go
+++ b/checks/mysql/check.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"github.com/hellofresh/health-go/v5"
 
 	_ "github.com/go-sql-driver/mysql" // import mysql driver
 )
@@ -18,36 +19,36 @@ type Config struct {
 // - connection establishing
 // - doing the ping command
 // - selecting mysql version
-func New(config Config) func(ctx context.Context) error {
-	return func(ctx context.Context) (checkErr error) {
+func New(config Config) func(ctx context.Context) health.CheckResponse {
+	return func(ctx context.Context) (checkResponse health.CheckResponse) {
 		db, err := sql.Open("mysql", config.DSN)
 		if err != nil {
-			checkErr = fmt.Errorf("MySQL health check failed on connect: %w", err)
+			checkResponse.Error = fmt.Errorf("MySQL health check failed on connect: %w", err)
 			return
 		}
 
 		defer func() {
-			// override checkErr only if there were no other errors
-			if err = db.Close(); err != nil && checkErr == nil {
-				checkErr = fmt.Errorf("MySQL health check failed on connection closing: %w", err)
+			// override checkResponse only if there were no other errors
+			if err = db.Close(); err != nil && checkResponse.Error == nil {
+				checkResponse.Error = fmt.Errorf("MySQL health check failed on connection closing: %w", err)
 			}
 		}()
 
 		err = db.PingContext(ctx)
 		if err != nil {
-			checkErr = fmt.Errorf("MySQL health check failed on ping: %w", err)
+			checkResponse.Error = fmt.Errorf("MySQL health check failed on ping: %w", err)
 			return
 		}
 
 		rows, err := db.QueryContext(ctx, `SELECT VERSION()`)
 		if err != nil {
-			checkErr = fmt.Errorf("MySQL health check failed on select: %w", err)
+			checkResponse.Error = fmt.Errorf("MySQL health check failed on select: %w", err)
 			return
 		}
 		defer func() {
-			// override checkErr only if there were no other errors
-			if err = rows.Close(); err != nil && checkErr == nil {
-				checkErr = fmt.Errorf("MySQL health check failed on rows closing: %w", err)
+			// override checkResponse only if there were no other errors
+			if err = rows.Close(); err != nil && checkResponse.Error == nil {
+				checkResponse.Error = fmt.Errorf("MySQL health check failed on rows closing: %w", err)
 			}
 		}()
 

--- a/checks/mysql/check_test.go
+++ b/checks/mysql/check_test.go
@@ -24,7 +24,7 @@ func TestNew(t *testing.T) {
 	})
 
 	err := check(context.Background())
-	require.NoError(t, err)
+	require.NoError(t, err.Error)
 }
 
 func TestEnsureConnectionIsClosed(t *testing.T) {
@@ -55,7 +55,7 @@ func TestEnsureConnectionIsClosed(t *testing.T) {
 	ctx := context.Background()
 	for i := 0; i < 10; i++ {
 		err := check(ctx)
-		assert.NoError(t, err)
+		assert.NoError(t, err.Error)
 		time.Sleep(100 * time.Millisecond)
 	}
 

--- a/checks/nats/check.go
+++ b/checks/nats/check.go
@@ -3,6 +3,7 @@ package nats
 import (
 	"context"
 	"fmt"
+	"github.com/hellofresh/health-go/v5"
 
 	"github.com/nats-io/nats.go"
 )
@@ -14,19 +15,21 @@ type Config struct {
 }
 
 // New creates new NATS health check that verifies the status of the connection.
-func New(config Config) func(ctx context.Context) error {
-	return func(ctx context.Context) error {
+func New(config Config) func(ctx context.Context) health.CheckResponse {
+	return func(ctx context.Context) (checkResponse health.CheckResponse) {
 		nc, err := nats.Connect(config.DSN)
 		if err != nil {
-			return fmt.Errorf("nats health check failed on client creation: %w", err)
+			checkResponse.Error = fmt.Errorf("nats health check failed on client creation: %w", err)
+			return
 		}
 		defer nc.Close()
 
 		status := nc.Status()
 		if status != nats.CONNECTED {
-			return fmt.Errorf("nats health check failed as connection status is %s", status)
+			checkResponse.Error = fmt.Errorf("nats health check failed as connection status is %s", status)
+			return
 		}
 
-		return nil
+		return
 	}
 }

--- a/checks/nats/check_test.go
+++ b/checks/nats/check_test.go
@@ -16,7 +16,7 @@ func TestNew(t *testing.T) {
 	})
 
 	err := check(context.Background())
-	require.NoError(t, err)
+	require.NoError(t, err.Error)
 }
 
 func getDSN(t *testing.T) string {

--- a/checks/pgx4/check.go
+++ b/checks/pgx4/check.go
@@ -3,6 +3,7 @@ package pgx4
 import (
 	"context"
 	"fmt"
+	"github.com/hellofresh/health-go/v5"
 
 	"github.com/jackc/pgx/v4"
 )
@@ -17,30 +18,30 @@ type Config struct {
 // - connection establishing
 // - doing the ping command
 // - selecting postgres version
-func New(config Config) func(ctx context.Context) error {
-	return func(ctx context.Context) (checkErr error) {
+func New(config Config) func(ctx context.Context) health.CheckResponse {
+	return func(ctx context.Context) (checkResponse health.CheckResponse) {
 		conn, err := pgx.Connect(ctx, config.DSN)
 		if err != nil {
-			checkErr = fmt.Errorf("PostgreSQL health check failed on connect: %w", err)
+			checkResponse.Error = fmt.Errorf("PostgreSQL health check failed on connect: %w", err)
 			return
 		}
 
 		defer func() {
-			// override checkErr only if there were no other errors
-			if err := conn.Close(ctx); err != nil && checkErr == nil {
-				checkErr = fmt.Errorf("PostgreSQL health check failed on connection closing: %w", err)
+			// override checkResponse only if there were no other errors
+			if err := conn.Close(ctx); err != nil && checkResponse.Error == nil {
+				checkResponse.Error = fmt.Errorf("PostgreSQL health check failed on connection closing: %w", err)
 			}
 		}()
 
 		err = conn.Ping(ctx)
 		if err != nil {
-			checkErr = fmt.Errorf("PostgreSQL health check failed on ping: %w", err)
+			checkResponse.Error = fmt.Errorf("PostgreSQL health check failed on ping: %w", err)
 			return
 		}
 
 		rows, err := conn.Query(ctx, `SELECT VERSION()`)
 		if err != nil {
-			checkErr = fmt.Errorf("PostgreSQL health check failed on select: %w", err)
+			checkResponse.Error = fmt.Errorf("PostgreSQL health check failed on select: %w", err)
 			return
 		}
 		defer func() {

--- a/checks/pgx4/check_test.go
+++ b/checks/pgx4/check_test.go
@@ -22,7 +22,7 @@ func TestNew(t *testing.T) {
 	})
 
 	err := check(context.Background())
-	require.NoError(t, err)
+	require.NoError(t, err.Error)
 }
 
 func TestEnsureConnectionIsClosed(t *testing.T) {
@@ -50,7 +50,7 @@ func TestEnsureConnectionIsClosed(t *testing.T) {
 
 	for i := 0; i < 10; i++ {
 		err := check(ctx)
-		assert.NoError(t, err)
+		assert.NoError(t, err.Error)
 		time.Sleep(100 * time.Millisecond)
 	}
 

--- a/checks/pgx5/check.go
+++ b/checks/pgx5/check.go
@@ -3,6 +3,7 @@ package pgx5
 import (
 	"context"
 	"fmt"
+	"github.com/hellofresh/health-go/v5"
 
 	"github.com/jackc/pgx/v5"
 )
@@ -17,30 +18,30 @@ type Config struct {
 // - connection establishing
 // - doing the ping command
 // - selecting postgres version
-func New(config Config) func(ctx context.Context) error {
-	return func(ctx context.Context) (checkErr error) {
+func New(config Config) func(ctx context.Context) health.CheckResponse {
+	return func(ctx context.Context) (checkResponse health.CheckResponse) {
 		conn, err := pgx.Connect(ctx, config.DSN)
 		if err != nil {
-			checkErr = fmt.Errorf("PostgreSQL health check failed on connect: %w", err)
+			checkResponse.Error = fmt.Errorf("PostgreSQL health check failed on connect: %w", err)
 			return
 		}
 
 		defer func() {
-			// override checkErr only if there were no other errors
-			if err := conn.Close(ctx); err != nil && checkErr == nil {
-				checkErr = fmt.Errorf("PostgreSQL health check failed on connection closing: %w", err)
+			// override checkResponse only if there were no other errors
+			if err := conn.Close(ctx); err != nil && checkResponse.Error == nil {
+				checkResponse.Error = fmt.Errorf("PostgreSQL health check failed on connection closing: %w", err)
 			}
 		}()
 
 		err = conn.Ping(ctx)
 		if err != nil {
-			checkErr = fmt.Errorf("PostgreSQL health check failed on ping: %w", err)
+			checkResponse.Error = fmt.Errorf("PostgreSQL health check failed on ping: %w", err)
 			return
 		}
 
 		rows, err := conn.Query(ctx, `SELECT VERSION()`)
 		if err != nil {
-			checkErr = fmt.Errorf("PostgreSQL health check failed on select: %w", err)
+			checkResponse.Error = fmt.Errorf("PostgreSQL health check failed on select: %w", err)
 			return
 		}
 		defer func() {

--- a/checks/pgx5/check_test.go
+++ b/checks/pgx5/check_test.go
@@ -22,7 +22,7 @@ func TestNew(t *testing.T) {
 	})
 
 	err := check(context.Background())
-	require.NoError(t, err)
+	require.NoError(t, err.Error)
 }
 
 func TestEnsureConnectionIsClosed(t *testing.T) {
@@ -50,7 +50,7 @@ func TestEnsureConnectionIsClosed(t *testing.T) {
 
 	for i := 0; i < 10; i++ {
 		err := check(ctx)
-		assert.NoError(t, err)
+		assert.NoError(t, err.Error)
 		time.Sleep(100 * time.Millisecond)
 	}
 

--- a/checks/postgres/check.go
+++ b/checks/postgres/check.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"github.com/hellofresh/health-go/v5"
 
 	_ "github.com/lib/pq" // import pg driver
 )
@@ -18,36 +19,36 @@ type Config struct {
 // - connection establishing
 // - doing the ping command
 // - selecting postgres version
-func New(config Config) func(ctx context.Context) error {
-	return func(ctx context.Context) (checkErr error) {
+func New(config Config) func(ctx context.Context) health.CheckResponse {
+	return func(ctx context.Context) (checkResponse health.CheckResponse) {
 		db, err := sql.Open("postgres", config.DSN)
 		if err != nil {
-			checkErr = fmt.Errorf("PostgreSQL health check failed on connect: %w", err)
+			checkResponse.Error = fmt.Errorf("PostgreSQL health check failed on connect: %w", err)
 			return
 		}
 
 		defer func() {
-			// override checkErr only if there were no other errors
-			if err := db.Close(); err != nil && checkErr == nil {
-				checkErr = fmt.Errorf("PostgreSQL health check failed on connection closing: %w", err)
+			// override checkResponse only if there were no other errors
+			if err := db.Close(); err != nil && checkResponse.Error == nil {
+				checkResponse.Error = fmt.Errorf("PostgreSQL health check failed on connection closing: %w", err)
 			}
 		}()
 
 		err = db.PingContext(ctx)
 		if err != nil {
-			checkErr = fmt.Errorf("PostgreSQL health check failed on ping: %w", err)
+			checkResponse.Error = fmt.Errorf("PostgreSQL health check failed on ping: %w", err)
 			return
 		}
 
 		rows, err := db.QueryContext(ctx, `SELECT VERSION()`)
 		if err != nil {
-			checkErr = fmt.Errorf("PostgreSQL health check failed on select: %w", err)
+			checkResponse.Error = fmt.Errorf("PostgreSQL health check failed on select: %w", err)
 			return
 		}
 		defer func() {
-			// override checkErr only if there were no other errors
-			if err = rows.Close(); err != nil && checkErr == nil {
-				checkErr = fmt.Errorf("PostgreSQL health check failed on rows closing: %w", err)
+			// override checkResponse only if there were no other errors
+			if err = rows.Close(); err != nil && checkResponse.Error == nil {
+				checkResponse.Error = fmt.Errorf("PostgreSQL health check failed on rows closing: %w", err)
 			}
 		}()
 

--- a/checks/postgres/check_test.go
+++ b/checks/postgres/check_test.go
@@ -24,7 +24,7 @@ func TestNew(t *testing.T) {
 	})
 
 	err := check(context.Background())
-	require.NoError(t, err)
+	require.NoError(t, err.Error)
 }
 
 func TestEnsureConnectionIsClosed(t *testing.T) {
@@ -52,7 +52,7 @@ func TestEnsureConnectionIsClosed(t *testing.T) {
 	ctx := context.Background()
 	for i := 0; i < 10; i++ {
 		err := check(ctx)
-		assert.NoError(t, err)
+		assert.NoError(t, err.Error)
 		time.Sleep(100 * time.Millisecond)
 	}
 

--- a/checks/rabbitmq/check_test.go
+++ b/checks/rabbitmq/check_test.go
@@ -18,7 +18,7 @@ func TestNew(t *testing.T) {
 	})
 
 	err := check(context.Background())
-	require.NoError(t, err)
+	require.NoError(t, err.Error)
 }
 
 func TestConfig(t *testing.T) {

--- a/checks/redis/check_test.go
+++ b/checks/redis/check_test.go
@@ -17,7 +17,7 @@ func TestNew(t *testing.T) {
 	})
 
 	err := check(context.Background())
-	require.NoError(t, err)
+	require.NoError(t, err.Error)
 }
 
 func getDSN(t *testing.T) string {

--- a/docs/index.md
+++ b/docs/index.md
@@ -41,14 +41,14 @@ func main() {
 		Name:      "rabbitmq",
 		Timeout:   time.Second * 5,
 		SkipOnErr: true,
-		Check: func(ctx context.Context) error {
+		Check: func(ctx context.Context) (healthResponse health.CheckResponse) {
 			// rabbitmq health check implementation goes here
-			return nil
+			return
 		}}, health.Config{
 		Name: "mongodb",
-		Check: func(ctx context.Context) error {
+		Check: func(ctx context.Context) (healthResponse health.CheckResponse) {
 			// mongo_db health check implementation goes here
-			return nil
+			return
 		},
 	},
 	))
@@ -88,14 +88,14 @@ func main() {
 		Name:      "rabbitmq",
 		Timeout:   time.Second * 5,
 		SkipOnErr: true,
-		Check: func(ctx context.Context) error {
+		Check: func(ctx context.Context) (healthResponse health.CheckResponse) {
 			// rabbitmq health check implementation goes here
-			return nil
+			return
 		}}, health.Config{
 		Name: "mongodb",
-		Check: func(ctx context.Context) error {
+		Check: func(ctx context.Context) (healthResponse health.CheckResponse) {
 			// mongo_db health check implementation goes here
-			return nil
+			return
 		},
 	},
 	))
@@ -135,7 +135,7 @@ curl localhost:3000/status
 HTTP/1.1 200 OK
 ```json
 {
-  "status": "OK",
+  "status": "passing",
   "timestamp": "2017-01-01T00:00:00.413567856+033:00",
   "system": {
     "version": "go1.8",
@@ -150,7 +150,7 @@ HTTP/1.1 200 OK
 HTTP/1.1 200 OK
 ```json
 {
-  "status": "Partially Available",
+  "status": "warning",
   "timestamp": "2017-01-01T00:00:00.413567856+033:00",
   "failures": {
     "rabbitmq": "Failed during rabbitmq health check"
@@ -168,7 +168,7 @@ HTTP/1.1 200 OK
 HTTP/1.1 503 Service Unavailable
 ```json
 {
-  "status": "Unavailable",
+  "status": "critical",
   "timestamp": "2017-01-01T00:00:00.413567856+033:00",
   "failures": {
     "mongodb": "Failed during mongodb health check"

--- a/health_test.go
+++ b/health_test.go
@@ -99,7 +99,7 @@ func TestHealthHandler(t *testing.T) {
 	err = json.NewDecoder(res.Body).Decode(&body)
 	require.NoError(t, err)
 
-	assert.Equal(t, string(StatusPartiallyAvailable), body["status"], "body returned wrong status")
+	assert.Equal(t, string(StatusWarning), body["status"], "body returned wrong status")
 
 	failure, ok := body["failures"]
 	assert.True(t, ok, "body returned nil failures field")
@@ -140,7 +140,7 @@ func TestHealth_Measure(t *testing.T) {
 	require.GreaterOrEqual(t, elapsed.Milliseconds(), (time.Second * 2).Milliseconds())
 	require.Less(t, elapsed.Milliseconds(), (time.Second * 5).Milliseconds())
 
-	assert.Equal(t, StatusUnavailable, result.Status)
+	assert.Equal(t, StatusCritical, result.Status)
 	assert.Equal(t, string(StatusTimeout), result.Failures["check1"])
 	assert.Equal(t, string(StatusTimeout), result.Failures["check2"])
 	assert.Nil(t, result.System)


### PR DESCRIPTION
Adds a CheckResonse struct which contains an `Error` and `IsWarning` which allows a health check to set soft-fail a health check when SkipOnErr is false.

Simplified returned status to match other health checking tools to better integrate with existing automation. While verbosity is nice for humans, it's easier for automation to parse standard strings.

| Old  | New |
| ------------- | ------------- |
| OK  | passing  |
| Partially Available  | warning  |
| Unavailable  | critical  |
| Timeout during health check  | timeout  |


Returned HTTP status codes now reflect proper status depending on the status
| Status  | HTTP Code |
| ------------- | ------------- |
| passing  | 200  |
| warning  | 429  |
| critical  | 503  |
