### PR TITLE
Add optional gocql config for customized cassandra connections

### DIFF
--- a/checks/cassandra/check.go
+++ b/checks/cassandra/check.go
@@ -10,10 +10,14 @@ import (
 
 // Config is the Cassandra checker configuration settings container.
 type Config struct {
-	// Hosts is a list of Cassandra hosts. At least one is required.
+	// Hosts is a list of Cassandra hosts. Optional if ClusterConfig is supplied.
 	Hosts []string
-	// Keyspace is the Cassandra keyspace to which you want to connect. Required.
+	// Keyspace is the Cassandra keyspace to which you want to connect. Optional if ClusterConfig is supplied.
 	Keyspace string
+	// ClusterConfig is a struct to configure the default cluster implementation of gocql. Can  be used in place of
+	// Hosts and Keyspace for more customized behavior.
+	// Optional if Hosts & Keyspace are supplied.
+	ClusterConfig *gocql.ClusterConfig
 }
 
 // New creates new Cassandra health check that verifies the following:
@@ -21,14 +25,20 @@ type Config struct {
 // - that queries can be executed by describing keyspaces
 func New(config Config) func(ctx context.Context) error {
 	return func(ctx context.Context) error {
-		if len(config.Hosts) < 1 || len(config.Keyspace) < 1 {
-			return errors.New("keyspace name and hosts are required to initialize cassandra health check")
+		var session *gocql.Session
+		var err error
+		if config.ClusterConfig == nil && (len(config.Hosts) < 1 || len(config.Keyspace) < 1) {
+			return errors.New("cassandra cluster config or keyspace name and hosts are required to initialize cassandra health check")
 		}
 
-		cluster := gocql.NewCluster(config.Hosts...)
-		cluster.Keyspace = config.Keyspace
+		if config.ClusterConfig != nil {
+			session, err = config.ClusterConfig.CreateSession()
+		} else {
+			cluster := gocql.NewCluster(config.Hosts...)
+			cluster.Keyspace = config.Keyspace
+			session, err = cluster.CreateSession()
+		}
 
-		session, err := cluster.CreateSession()
 		if err != nil {
 			return fmt.Errorf("cassandra health check failed on connect: %w", err)
 		}

--- a/checks/cassandra/check.go
+++ b/checks/cassandra/check.go
@@ -10,40 +10,36 @@ import (
 
 // Config is the Cassandra checker configuration settings container.
 type Config struct {
-	// Hosts is a list of Cassandra hosts. Optional if ClusterConfig is supplied.
+	// Hosts is a list of Cassandra hosts. Optional if Session is supplied.
 	Hosts []string
-	// Keyspace is the Cassandra keyspace to which you want to connect. Optional if ClusterConfig is supplied.
+	// Keyspace is the Cassandra keyspace to which you want to connect. Optional if Session is supplied.
 	Keyspace string
-	// ClusterConfig is a struct to configure the default cluster implementation of gocql. Can  be used in place of
-	// Hosts and Keyspace for more customized behavior.
+	// Session is a gocql session and can be used in place of Hosts and Keyspace. Recommended.
 	// Optional if Hosts & Keyspace are supplied.
-	ClusterConfig *gocql.ClusterConfig
+	Session *gocql.Session
 }
 
-// New creates new Cassandra health check that verifies the following:
-// - that a connection can be established through creating a session
-// - that queries can be executed by describing keyspaces
+// New creates new Cassandra health check that verifies that a connection exists and can be used to query the cluster.
 func New(config Config) func(ctx context.Context) error {
 	return func(ctx context.Context) error {
 		var session *gocql.Session
 		var err error
-		if config.ClusterConfig == nil && (len(config.Hosts) < 1 || len(config.Keyspace) < 1) {
+		if config.Session == nil && (len(config.Hosts) < 1 || len(config.Keyspace) < 1) {
 			return errors.New("cassandra cluster config or keyspace name and hosts are required to initialize cassandra health check")
 		}
 
-		if config.ClusterConfig != nil {
-			session, err = config.ClusterConfig.CreateSession()
+		if config.Session != nil {
+			session = config.Session
 		} else {
 			cluster := gocql.NewCluster(config.Hosts...)
 			cluster.Keyspace = config.Keyspace
 			session, err = cluster.CreateSession()
+			defer session.Close()
 		}
 
 		if err != nil {
 			return fmt.Errorf("cassandra health check failed on connect: %w", err)
 		}
-
-		defer session.Close()
 
 		err = session.Query("DESCRIBE KEYSPACES;").WithContext(ctx).Exec()
 		if err != nil {

--- a/checks/cassandra/check_test.go
+++ b/checks/cassandra/check_test.go
@@ -26,6 +26,15 @@ func TestNew(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestNew_withClusterConfig(t *testing.T) {
+	initDB(t)
+	check := New(Config{
+		ClusterConfig: gocql.NewCluster(getHosts(t)...),
+	})
+	err := check(context.Background())
+	require.NoError(t, err)
+}
+
 func TestNewWithError(t *testing.T) {
 	check := New(Config{})
 

--- a/checks/cassandra/check_test.go
+++ b/checks/cassandra/check_test.go
@@ -28,10 +28,16 @@ func TestNew(t *testing.T) {
 
 func TestNew_withClusterConfig(t *testing.T) {
 	initDB(t)
+	cluster := gocql.NewCluster(getHosts(t)...)
+	cluster.Keyspace = KEYSPACE
+	session, err := cluster.CreateSession()
+	require.NoError(t, err)
+
 	check := New(Config{
-		ClusterConfig: gocql.NewCluster(getHosts(t)...),
+		Session: session,
 	})
-	err := check(context.Background())
+
+	err = check(context.Background())
 	require.NoError(t, err)
 }
 


### PR DESCRIPTION
For Cassandra connections that might require more information to connect -for example, auth info or SSL options - it's best to use a session established by the user.