### PR TITLE
Update query used to check for Cassandra connectedness

### DIFF
--- a/checks/cassandra/check.go
+++ b/checks/cassandra/check.go
@@ -33,7 +33,7 @@ func New(config Config) func(ctx context.Context) error {
 			return fmt.Errorf("cassandra health check failed on connect: %w", err)
 		}
 
-		err = session.Query("DESCRIBE KEYSPACES;").WithContext(ctx).Exec()
+		err = session.Query("SELECT * FROM system_schema.keyspaces;").WithContext(ctx).Exec()
 		if err != nil {
 			return fmt.Errorf("cassandra health check failed on describe: %w", err)
 		}


### PR DESCRIPTION
I discovered rather late that `DESCRIBE KEYSPACES` is specifically a cqlsh command and might not be supported by every Cassandra version.

Using `SELECT * FROM system_schema.keyspaces` queries Cassandra's system schema directly - going around any tool-specific language - and is [indicated for Cassandra versions 5.0 and higher](https://docs.datastax.com/en/dse/5.1/cql/cql/cql_using/useQuerySystemTable.html). 