### PR TITLE
feat: support reusing an existing mongo client to prevent connection churn

### DIFF
--- a/checks/mongo/check.go
+++ b/checks/mongo/check.go
@@ -2,6 +2,7 @@ package mongo
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -16,6 +17,8 @@ const (
 	defaultTimeoutPing       = 5 * time.Second
 )
 
+var errNilClient = errors.New("mongoDB health check failed on ping: nil mongo client")
+
 // Config is the MongoDB checker configuration settings container.
 type Config struct {
 	// DSN is the MongoDB instance connection DSN. Required.
@@ -29,9 +32,38 @@ type Config struct {
 	TimeoutPing time.Duration
 }
 
+// NewPingCheck creates a MongoDB health check using an existing client.
+// The caller is responsible for managing the client's lifecycle.
+func NewPingCheck(client *mongo.Client, timeout time.Duration) func(ctx context.Context) error {
+	if client == nil {
+		return func(context.Context) error {
+			return errNilClient
+		}
+	}
+
+	if timeout == 0 {
+		timeout = defaultTimeoutPing
+	}
+
+	return func(ctx context.Context) error {
+		ctxPing, cancelPing := context.WithTimeout(ctx, timeout)
+		defer cancelPing()
+
+		err := client.Ping(ctxPing, readpref.Primary())
+		if err != nil {
+			return fmt.Errorf("mongoDB health check failed on ping: %w", err)
+		}
+
+		return nil
+	}
+}
+
 // New creates new MongoDB health check that verifies the following:
 // - connection establishing
 // - doing the ping command
+//
+// Deprecated: use NewPingCheck instead. It uses an existing *mongo.Client
+// to avoid connection churn.
 func New(config Config) func(ctx context.Context) error {
 	if config.TimeoutConnect == 0 {
 		config.TimeoutConnect = defaultTimeoutConnect

--- a/checks/mongo/check.go
+++ b/checks/mongo/check.go
@@ -17,12 +17,16 @@ const (
 	defaultTimeoutPing       = 5 * time.Second
 )
 
-var errNilClient = errors.New("mongoDB health check failed on ping: nil mongo client")
-
 // Config is the MongoDB checker configuration settings container.
 type Config struct {
-	// DSN is the MongoDB instance connection DSN. Required.
+	// DSN is the MongoDB instance connection DSN. Optional if Client is supplied.
 	DSN string
+
+	// Client is an existing mongo client and can be used in place of DSN. Recommended,
+	// since it reuses the application's connection pool instead of establishing and
+	// tearing down a new connection on every check. The caller is responsible for
+	// managing the client's lifecycle. Optional if DSN is supplied.
+	Client *mongo.Client
 
 	// TimeoutConnect defines timeout for establishing mongo connection, if not set - default value is used
 	TimeoutConnect time.Duration
@@ -32,38 +36,9 @@ type Config struct {
 	TimeoutPing time.Duration
 }
 
-// NewPingCheck creates a MongoDB health check using an existing client.
-// The caller is responsible for managing the client's lifecycle.
-func NewPingCheck(client *mongo.Client, timeout time.Duration) func(ctx context.Context) error {
-	if client == nil {
-		return func(context.Context) error {
-			return errNilClient
-		}
-	}
-
-	if timeout == 0 {
-		timeout = defaultTimeoutPing
-	}
-
-	return func(ctx context.Context) error {
-		ctxPing, cancelPing := context.WithTimeout(ctx, timeout)
-		defer cancelPing()
-
-		err := client.Ping(ctxPing, readpref.Primary())
-		if err != nil {
-			return fmt.Errorf("mongoDB health check failed on ping: %w", err)
-		}
-
-		return nil
-	}
-}
-
 // New creates new MongoDB health check that verifies the following:
-// - connection establishing
+// - connection establishing (skipped when an existing Client is supplied)
 // - doing the ping command
-//
-// Deprecated: use NewPingCheck instead. It uses an existing *mongo.Client
-// to avoid connection churn.
 func New(config Config) func(ctx context.Context) error {
 	if config.TimeoutConnect == 0 {
 		config.TimeoutConnect = defaultTimeoutConnect
@@ -78,28 +53,16 @@ func New(config Config) func(ctx context.Context) error {
 	}
 
 	return func(ctx context.Context) (checkErr error) {
-		client, err := mongo.NewClient(options.Client().ApplyURI(config.DSN))
+		shutdown, client, err := initClient(ctx, config)
 		if err != nil {
-			checkErr = fmt.Errorf("mongoDB health check failed on client creation: %w", err)
-			return
-		}
-
-		ctxConn, cancelConn := context.WithTimeout(ctx, config.TimeoutConnect)
-		defer cancelConn()
-
-		err = client.Connect(ctxConn)
-		if err != nil {
-			checkErr = fmt.Errorf("mongoDB health check failed on connect: %w", err)
+			checkErr = err
 			return
 		}
 
 		defer func() {
-			ctxDisc, cancelDisc := context.WithTimeout(ctx, config.TimeoutDisconnect)
-			defer cancelDisc()
-
 			// override checkErr only if there were no other errors
-			if err := client.Disconnect(ctxDisc); err != nil && checkErr == nil {
-				checkErr = fmt.Errorf("mongoDB health check failed on closing connection: %w", err)
+			if err := shutdown(ctx); err != nil && checkErr == nil {
+				checkErr = err
 			}
 		}()
 
@@ -114,4 +77,40 @@ func New(config Config) func(ctx context.Context) error {
 
 		return
 	}
+}
+
+func initClient(ctx context.Context, c Config) (func(ctx context.Context) error, *mongo.Client, error) {
+	if c.Client != nil {
+		return func(context.Context) error { return nil }, c.Client, nil
+	}
+
+	if c.DSN == "" {
+		return nil, nil, errors.New("mongoDB DSN or an existing client is required to initialize mongoDB health check")
+	}
+
+	client, err := mongo.NewClient(options.Client().ApplyURI(c.DSN))
+	if err != nil {
+		return nil, nil, fmt.Errorf("mongoDB health check failed on client creation: %w", err)
+	}
+
+	ctxConn, cancelConn := context.WithTimeout(ctx, c.TimeoutConnect)
+	defer cancelConn()
+
+	err = client.Connect(ctxConn)
+	if err != nil {
+		return nil, nil, fmt.Errorf("mongoDB health check failed on connect: %w", err)
+	}
+
+	shutdown := func(ctx context.Context) error {
+		ctxDisc, cancelDisc := context.WithTimeout(ctx, c.TimeoutDisconnect)
+		defer cancelDisc()
+
+		if err := client.Disconnect(ctxDisc); err != nil {
+			return fmt.Errorf("mongoDB health check failed on closing connection: %w", err)
+		}
+
+		return nil
+	}
+
+	return shutdown, client, nil
 }

--- a/checks/mongo/check_test.go
+++ b/checks/mongo/check_test.go
@@ -2,14 +2,45 @@ package mongo
 
 import (
 	"context"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
 
 const mgDSNEnv = "HEALTH_GO_MG_DSN"
+
+func TestNewPingCheck(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("success check with valid client", func(t *testing.T) {
+		dsn := getDSN(t)
+
+		client, err := mongo.Connect(ctx, options.Client().ApplyURI(dsn))
+		require.NoError(t, err)
+
+		defer func() {
+			errDisc := client.Disconnect(ctx)
+			require.NoError(t, errDisc)
+		}()
+
+		check := NewPingCheck(client, 0)
+
+		err = check(ctx)
+		require.NoError(t, err)
+	})
+
+	t.Run("fails on nil client", func(t *testing.T) {
+		check := NewPingCheck(nil, 5*time.Second)
+
+		err := check(ctx)
+		require.ErrorIs(t, err, errNilClient)
+	})
+}
 
 func TestNew(t *testing.T) {
 	check := New(Config{

--- a/checks/mongo/check_test.go
+++ b/checks/mongo/check_test.go
@@ -2,45 +2,17 @@ package mongo
 
 import (
 	"context"
-	"go.mongodb.org/mongo-driver/mongo"
-	"go.mongodb.org/mongo-driver/mongo/options"
 	"os"
 	"strings"
 	"testing"
-	"time"
+
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
 
 	"github.com/stretchr/testify/require"
 )
 
 const mgDSNEnv = "HEALTH_GO_MG_DSN"
-
-func TestNewPingCheck(t *testing.T) {
-	ctx := context.Background()
-
-	t.Run("success check with valid client", func(t *testing.T) {
-		dsn := getDSN(t)
-
-		client, err := mongo.Connect(ctx, options.Client().ApplyURI(dsn))
-		require.NoError(t, err)
-
-		defer func() {
-			errDisc := client.Disconnect(ctx)
-			require.NoError(t, errDisc)
-		}()
-
-		check := NewPingCheck(client, 0)
-
-		err = check(ctx)
-		require.NoError(t, err)
-	})
-
-	t.Run("fails on nil client", func(t *testing.T) {
-		check := NewPingCheck(nil, 5*time.Second)
-
-		err := check(ctx)
-		require.ErrorIs(t, err, errNilClient)
-	})
-}
 
 func TestNew(t *testing.T) {
 	check := New(Config{
@@ -49,6 +21,32 @@ func TestNew(t *testing.T) {
 
 	err := check(context.Background())
 	require.NoError(t, err)
+}
+
+func TestNew_withClient(t *testing.T) {
+	ctx := context.Background()
+
+	client, err := mongo.Connect(ctx, options.Client().ApplyURI(getDSN(t)))
+	require.NoError(t, err)
+
+	defer func() {
+		errDisc := client.Disconnect(ctx)
+		require.NoError(t, errDisc)
+	}()
+
+	check := New(Config{
+		Client: client,
+	})
+
+	err = check(ctx)
+	require.NoError(t, err)
+}
+
+func TestNewWithError(t *testing.T) {
+	check := New(Config{})
+
+	err := check(context.Background())
+	require.Error(t, err)
 }
 
 func getDSN(t *testing.T) string {


### PR DESCRIPTION
## Summary

The existing mongo check creates and tears down a new database connection on every periodic run. This causes significant overhead and socket exhaustion (TCP TIME_WAIT leaks), and it does not verify the health of the application's actual connection pool. MongoDB's documentation recommends reusing a single client: https://www.mongodb.com/docs/drivers/go/current/connect/mongoclient/#:~:text=Reuse%20Your%20Client%20with%20Connection%20Pools

This PR adds an optional `Client *mongo.Client` field to `Config`. When it is supplied, the check reuses the application's client (and its connection pool) and only runs the ping command; the caller stays responsible for the client's lifecycle. When it is not supplied, the previous DSN-based behavior is unchanged: the check still establishes a fresh connection, pings, and disconnects with the existing three timeouts.

The API follows the same pattern this library already uses for cassandra, where an existing `Session` can be supplied in `Config` in place of `Hosts` and `Keyspace` (see `checks/cassandra/check.go`), so no new constructor is introduced and nothing is deprecated.